### PR TITLE
Fixing README typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Add the addons folder in you project like your would with any other plugin. Go t
 ##### Using the plugin
 Wherever you want to use just paste this:
 ```
-var toast = Toast.new("Toast text", Toast.LENGHT_SHORT)
+var toast = Toast.new("Toast text", Toast.LENGTH_SHORT)
 get_node("/root").add_child(toast)
 toast.show()
 ```
@@ -22,7 +22,7 @@ Toast
 
 Methods
 -------
-| Toast | new(text: String, lenght: ToastLenght, mstyle: ToastStyle = `preload( "style_resource/default.tres")` ) |
+| Toast | new(text: String, length: ToastLenght, mstyle: ToastStyle = `preload( "style_resource/default.tres")` ) |
 |-|-|
 | void | show() |
 
@@ -37,8 +37,8 @@ Enumerations
 ============
 
 enum `ToastLenght`:\
-    LENGHT_SHORT: the toast will last for 1.5 seconds, including the fading\
-    LENGHT_LONG: the toast will last for 3 seconds, including the fading
+    LENGTH_SHORT: the toast will last for 1.5 seconds, including the fading\
+    LENGTH_LONG: the toast will last for 3 seconds, including the fading
 
 Signals
 =======
@@ -54,8 +54,8 @@ Property Descriptions
 Methods Descriptions
 --------------------
 
-* `Toast new(text: String, lenght: ToastLenght)`\
-    Returns a new Toast. The `text` is the text that will be shown inside of the toast. `lenght ` represents the duration lenght. `mstyle` represents the toast syle stored in style(see propriety descriptions).
+* `Toast new(text: String, length: ToastLenght)`\
+    Returns a new Toast. The `text` is the text that will be shown inside of the toast. `length ` represents the duration length. `mstyle` represents the toast syle stored in style(see propriety descriptions).
 * `void show()`\
     Starts the toast.
 


### PR DESCRIPTION
Hello @rares45 

Thank you by your plugin.
When I was using it in my project I noticed that the toast length enumerator LENGHT_SHORT, as mentioned in README file, do not exist and looking to your source code I find out that you was using LENGTH_SHORT.

So I made that commit fixing every "LENGHT" typo in your documentation.